### PR TITLE
chore/dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,20 +23,15 @@
   },
   "main": "ng2-fullpage.js",
   "dependencies": {
+    "@angular/common": "^2.0.0-rc.4",
+    "@angular/compiler": "^2.0.0-rc.4",
+    "@angular/core": "^2.0.0-rc.4",
+    "@angular/platform-browser": "^2.0.0-rc.4",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.4",
     "jquery": "^3.0.0",
     "fullpage.js": "^2.8.0"
   },
-  "peerDependencies": {
-    "@angular/common": "^2.0.0-rc.1",
-    "@angular/compiler": "^2.0.0-rc.1",
-    "@angular/core": "^2.0.0-rc.1"
-  },
   "devDependencies": {
-    "@angular/common": "^2.0.0-rc.1",
-    "@angular/compiler": "^2.0.0-rc.1",
-    "@angular/core": "^2.0.0-rc.1",
-    "@angular/platform-browser": "^2.0.0-rc.1",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
     "awesome-typescript-loader": "^1.0.0",
     "babel-core": "^6.9.0",
     "babel-loader": "^6.2.4",
@@ -84,7 +79,7 @@
     "ts-helpers": "^1.1.1",
     "tslint": "^3.10.2",
     "tslint-loader": "^2.1.4",
-    "typedoc": "^0.3.12",
+    "typedoc": "^0.4.4",
     "typescript": "^1.8.10",
     "typings": "^1.0.4",
     "unminified-webpack-plugin": "^1.0.0",

--- a/test/spec/fullpage/fullpage.directive.spec.ts
+++ b/test/spec/fullpage/fullpage.directive.spec.ts
@@ -2,8 +2,7 @@
  * @author Meiblorn (Vadim Fedorenko) <meiblorn@gmail.com | admin@meiblorn.com> on 15/05/16.
  */
 
-import {TestComponentBuilder} from '@angular/compiler/testing';
-import {async, describe, inject, it} from '@angular/core/testing';
+import {TestComponentBuilder, async, describe, inject, it} from '@angular/core/testing';
 
 import {Component, Input} from '@angular/core';
 import {MnFullpageDirective, MnFullpageOptions} from 'ng2-fullpage';


### PR DESCRIPTION
- Updating Angluar2 dependencies to RC4

- Updating fullpage.diretive.spect.ts to accommodate the breaking changes
of Angular2 RC4 - see Angular’s changeling

- Updating TypeDoc dependency to v0.4.4