### PR TITLE
no postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "tests": "npm run test",
     "test:watch": "npm run watch:test",
     "codeclimate": "codeclimate-test-reporter < build/reports/lcov-report/lcov.info",
-    "postinstall": "npm run typings -- install",
     "docs": "npm run typedoc -- --options typedoc.json --exclude '**/*.spec.ts' ./components/"
   }
 }


### PR DESCRIPTION
typescript 2 deprecated the typings tool in favor to use npm.
If you type 2, as the latest angular-cli, you wont be able install ng2-fullpage because it will fail the post install step